### PR TITLE
Fix gravity

### DIFF
--- a/objects.py
+++ b/objects.py
@@ -9,6 +9,17 @@ class GoslingAgent(BaseAgent):
     #This is the main object of Gosling Utils. It holds/updates information about the game and runs routines
     #All utils rely on information being structured and accessed the same way as configured in this class
     def initialize_agent(self):
+        mutators = self.get_match_settings().MutatorSettings()
+
+        gravity = [
+            Vector(z=-650),
+            Vector(z=-325),
+            Vector(z=-1137.5),
+            Vector(z=-3250)
+        ]
+
+        self.gravity = gravity[mutators.GravityOption()]
+
         #A list of cars for both teammates and opponents
         self.friends = []
         self.foes = []

--- a/objects.py
+++ b/objects.py
@@ -12,10 +12,10 @@ class GoslingAgent(BaseAgent):
         mutators = self.get_match_settings().MutatorSettings()
 
         gravity = [
-            Vector(z=-650),
-            Vector(z=-325),
-            Vector(z=-1137.5),
-            Vector(z=-3250)
+            Vector3(z=-650),
+            Vector3(z=-325),
+            Vector3(z=-1137.5),
+            Vector3(z=-3250)
         ]
 
         self.gravity = gravity[mutators.GravityOption()]

--- a/objects.py
+++ b/objects.py
@@ -12,10 +12,10 @@ class GoslingAgent(BaseAgent):
         mutators = self.get_match_settings().MutatorSettings()
 
         gravity = [
-            Vector3(z=-650),
-            Vector3(z=-325),
-            Vector3(z=-1137.5),
-            Vector3(z=-3250)
+            Vector3(0, 0, -650),
+            Vector3(0, 0, -325),
+            Vector3(0, 0, -1137.5),
+            Vector3(0, 0, -3250)
         ]
 
         self.gravity = gravity[mutators.GravityOption()]

--- a/routines.py
+++ b/routines.py
@@ -41,7 +41,7 @@ class aerial_shot():
 
         speed_required = distance_remaining / time_remaining
         #When still on the ground we pretend gravity doesn't exist, for better or worse
-        acceleration_required = backsolve(self.intercept,agent.me,time_remaining, 0 if self.jump_time == 0 else 325)
+        acceleration_required = backsolve(self.intercept,agent.me,time_remaining, 0 if self.jump_time == 0 else agent.gravity.z * -1)
         local_acceleration_required = agent.me.local(acceleration_required)
 
         #The adjustment causes the car to circle around the dodge point in an effort to line up with the shot vector
@@ -254,7 +254,7 @@ class jump_shot():
         distance_remaining = car_to_dodge_point.magnitude()
 
         speed_required = distance_remaining / time_remaining
-        acceleration_required = backsolve(self.dodge_point,agent.me,time_remaining,0 if not self.jumping else 650)
+        acceleration_required = backsolve(self.dodge_point,agent.me,time_remaining,0 if not self.jumping else agent.gravity.z)
         local_acceleration_required = agent.me.local(acceleration_required)
 
         #The adjustment causes the car to circle around the dodge point in an effort to line up with the shot vector

--- a/routines.py
+++ b/routines.py
@@ -254,7 +254,7 @@ class jump_shot():
         distance_remaining = car_to_dodge_point.magnitude()
 
         speed_required = distance_remaining / time_remaining
-        acceleration_required = backsolve(self.dodge_point,agent.me,time_remaining,0 if not self.jumping else agent.gravity.z)
+        acceleration_required = backsolve(self.dodge_point,agent.me,time_remaining,0 if not self.jumping else agent.gravity.z * -1)
         local_acceleration_required = agent.me.local(acceleration_required)
 
         #The adjustment causes the car to circle around the dodge point in an effort to line up with the shot vector


### PR DESCRIPTION
GoslingUtils now adapts correctly based on the gravity mutator
The `aerial_shot` routine used to have `325` as the default gravity, but this was only true when the low gravity mutator was selected. This now no longer happens. I think this was a big mistake that resulted in some... whiffs.